### PR TITLE
docs: Clarify fitness terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Requires Python 3.10+. `uv` is only needed for the `uv` / `uvx` workflow.
 <summary><strong>What it does</strong></summary>
 <br>
 
-- codify quality gates and architecture constraints as reusable fitness specs
+- codify quality gates and architecture constraints as reusable guardrail specs
 - run checks by `fast` / `normal` / `deep` tiers
 - run change-aware checks on diffs with weighted scoring and hard gates
 - route risky changes to deeper validation with `review-trigger`
@@ -82,6 +82,13 @@ Requires Python 3.10+. `uv` is only needed for the `uv` / `uvx` workflow.
 Additional design context:
 
 - `tools/entrix/docs/adr/README.md`: Entrix architecture decisions and rationale
+
+## Terminology
+
+Entrix uses **fitness** in the evolutionary architecture sense: a fitness
+function is an executable check that measures whether a codebase still satisfies
+a quality or architecture goal. In product-facing language, you can think of
+these as versioned quality guardrails.
 
 ## Requirements
 
@@ -131,7 +138,7 @@ uvx entrix install --repo .
 
 ## First Run
 
-### 1. Create a fitness spec
+### 1. Create a guardrail spec
 
 By default, `entrix run` looks for specs under the current project's:
 
@@ -344,8 +351,8 @@ pip install -e .
 
 Most repositories only need these three commands:
 
-- `entrix run`: execute fitness checks from `docs/fitness/*.md`
-- `entrix validate`: validate the fitness configuration
+- `entrix run`: execute guardrail checks from `docs/fitness/*.md`
+- `entrix validate`: validate the guardrail configuration
 - `entrix review-trigger`: escalate risky diffs to human review
 
 Use `entrix analyze long-file` for oversized-file structure analysis and `entrix graph ...` for graph-backed impact analysis.
@@ -359,7 +366,7 @@ Entrix includes copyable examples under [`examples/`](./examples/):
 
 ### `entrix run`
 
-Runs dimension-based fitness checks loaded from `docs/fitness/*.md`.
+Runs dimension-based guardrail checks loaded from `docs/fitness/*.md`.
 
 Common flags:
 
@@ -507,11 +514,11 @@ entrix graph review-context --base HEAD~1 --output context.json
 
 ## Preset System
 
-Entrix uses a preset system to adapt behavior to different project layouts. The default `ProjectPreset` looks for fitness specs in `docs/fitness/` and review triggers in `docs/fitness/review-triggers.yaml`.
+Entrix uses a preset system to adapt behavior to different project layouts. The default `ProjectPreset` looks for guardrail specs in `docs/fitness/` and review triggers in `docs/fitness/review-triggers.yaml`.
 
 Custom presets can override:
 
-- `fitness_dir(project_root)` — where to find fitness spec files
+- `fitness_dir(project_root)` — where to find guardrail spec files
 - `review_trigger_config(project_root)` — path to the review trigger YAML
 - `should_ignore_changed_file(file_path)` — filter out irrelevant changed files
 - `domains_from_files(files)` — extract domain tags from changed file paths
@@ -520,7 +527,7 @@ A built-in `RoutaPreset` is included as a reference implementation for monorepo 
 
 ## AI-Friendly Authoring Notes
 
-If an AI agent is generating or updating fitness specs, these conventions work best:
+If an AI agent is generating or updating guardrail specs, these conventions work best:
 
 - keep one dimension per file
 - make the frontmatter executable and the body explanatory

--- a/entrix/cli.py
+++ b/entrix/cli.py
@@ -598,7 +598,7 @@ def _collect_run_files(args: argparse.Namespace, project_root: Path) -> list[str
 
 
 def cmd_run(args: argparse.Namespace) -> int:
-    """Run fitness checks (main command)."""
+    """Run architecture fitness functions as executable guardrail checks."""
     project_root = _find_project_root()
     _find_fitness_dir(project_root)
     preset = get_project_preset()
@@ -1140,11 +1140,14 @@ def cmd_analyze_long_file(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="entrix",
-        description="Evolutionary architecture fitness engine for change-aware verification",
+        description=(
+            "Executable quality guardrails powered by evolutionary architecture "
+            "fitness functions"
+        ),
     )
     subparsers = parser.add_subparsers(dest="command")
 
-    run_parser = subparsers.add_parser("run", help="Run fitness checks")
+    run_parser = subparsers.add_parser("run", help="Run guardrail checks")
     run_parser.add_argument(
         "--tier", choices=["fast", "normal", "deep"], help="Run only metrics up to this tier"
     )

--- a/entrix/model.py
+++ b/entrix/model.py
@@ -1,5 +1,9 @@
 """Domain model for evolutionary architecture fitness functions.
 
+In Entrix, "fitness" follows the evolutionary architecture term: an executable
+check that measures whether a codebase still satisfies a quality or architecture
+goal. User-facing text often calls the same concept a guardrail.
+
 Aligns with concepts from "Building Evolutionary Architectures":
 - Fitness Function → Metric (an executable architectural check)
 - Dimension → architectural characteristic category

--- a/entrix/reporters/terminal.py
+++ b/entrix/reporters/terminal.py
@@ -15,7 +15,7 @@ class TerminalReporter:
         self, *, dry_run: bool = False, tier: str | None = None, parallel: bool = False
     ) -> None:
         print("=" * 60)
-        print("FITNESS FUNCTION REPORT")
+        print("GUARDRAIL CHECK REPORT")
         if dry_run:
             print("(DRY-RUN MODE)")
         if tier:

--- a/entrix/reporters/visual.py
+++ b/entrix/reporters/visual.py
@@ -265,7 +265,7 @@ class RichReporter:
 
         Console, Table, Text = rich
         console = Console()
-        table = Table(title="Fitness Scorecard", show_lines=False)
+        table = Table(title="Guardrail Scorecard", show_lines=False)
         table.add_column("Dimension", style="bold")
         table.add_column("Score")
         table.add_column("Weight", justify="right")

--- a/entrix/reporters/visual.py
+++ b/entrix/reporters/visual.py
@@ -128,7 +128,7 @@ class RichLiveProgressReporter:
 
         lines = [
             (
-                f"[fitness] {counts['passed']} passed | {counts['failed']} failed | "
+                f"[guardrail] {counts['passed']} passed | {counts['failed']} failed | "
                 f"{counts['running']} running | {counts['queued']} queued | {hard_failures} hard-gate failures"
             )
         ]
@@ -144,7 +144,7 @@ class RichLiveProgressReporter:
                 f"[{idx}/{len(self._order)}] {state['status'].upper()}({gate}) {metric_name}{duration}"
             )
         if self._tail:
-            lines.append("[fitness tail]")
+            lines.append("[guardrail tail]")
             lines.extend(self._tail)
         return lines
 
@@ -180,7 +180,7 @@ class RichLiveProgressReporter:
                 hard_failures += 1
 
         summary = Text.assemble(
-            ("[fitness] ", "bold"),
+            ("[guardrail] ", "bold"),
             (f"{counts['passed']} passed", "green"),
             (" | ", ""),
             (f"{counts['failed']} failed", "red"),
@@ -214,7 +214,7 @@ class RichLiveProgressReporter:
 
         renderables = [summary, table]
         if self._tail:
-            renderables.append(Panel("\n".join(self._tail), title="fitness tail", border_style="yellow"))
+            renderables.append(Panel("\n".join(self._tail), title="guardrail tail", border_style="yellow"))
         return Group(*renderables)
 
 

--- a/entrix/server.py
+++ b/entrix/server.py
@@ -1,4 +1,4 @@
-"""MCP server — expose fitness functions as tools for AI agent integration."""
+"""MCP server — expose guardrail checks as tools for AI agent integration."""
 
 from __future__ import annotations
 
@@ -20,7 +20,13 @@ def create_server(project_root: Path | None = None):
     if project_root is None:
         project_root = Path.cwd()
 
-    mcp = FastMCP("entrix", instructions="Evolutionary architecture fitness engine")
+    mcp = FastMCP(
+        "entrix",
+        instructions=(
+            "Executable quality guardrails powered by evolutionary architecture "
+            "fitness functions"
+        ),
+    )
 
     @mcp.tool()
     def run_fitness(
@@ -30,7 +36,7 @@ def create_server(project_root: Path | None = None):
         dry_run: bool = False,
         min_score: float = 80.0,
     ) -> dict:
-        """Run fitness checks and return a structured report.
+        """Run guardrail checks and return a structured fitness report.
 
         Args:
             tier: Filter by tier (fast, normal, deep). None runs all.

--- a/entrix/structure/protocol.py
+++ b/entrix/structure/protocol.py
@@ -1,6 +1,6 @@
 """Protocol definition for structural analyzers.
 
-Decouples the fitness engine from any specific code graph implementation.
+Decouples the guardrail engine from any specific code graph implementation.
 The built-in Tree-sitter adapter is the default backend, but the Protocol allows
 swapping in alternative implementations (external code-review-graph, remote
 service, etc.).

--- a/skills/entrix/SKILL.md
+++ b/skills/entrix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: entrix
-description: Set up or repair Entrix fitness specs in the current repository by discovering real quality signals, generating docs/fitness, and iterating with entrix validation until the result is executable. Use when the user asks to bootstrap entrix, add or split fitness dimensions, repair invalid fitness specs, or make docs/fitness actually runnable.
+description: Set up or repair Entrix guardrail specs in the current repository by discovering real quality signals, generating docs/fitness, and iterating with entrix validation until the result is executable. Use when the user asks to bootstrap entrix, add or split fitness dimensions, repair invalid guardrail specs, or make docs/fitness actually runnable.
 license: MIT
 ---
 
@@ -9,6 +9,10 @@ license: MIT
 Goal: leave the target repository with a working `docs/fitness/` configuration
 that matches real tooling, is discoverable from the repository entrypoint, and
 passes Entrix validation instead of merely looking plausible.
+
+Entrix uses `fitness` in the evolutionary architecture sense: an executable
+check that measures whether a codebase still satisfies a quality or architecture
+goal. The user-facing description is "quality guardrail".
 
 This skill now uses a small entrypoint plus reusable spec files under
 `specs/`. Read those specs instead of improvising schema details.

--- a/tests/test_visual_reporter.py
+++ b/tests/test_visual_reporter.py
@@ -93,8 +93,8 @@ def test_rich_live_progress_reporter_tracks_state_and_tail(monkeypatch):
     )
 
     lines = reporter.snapshot_lines()
-    assert lines[0] == "[fitness] 1 passed | 1 failed | 0 running | 0 queued | 1 hard-gate failures"
+    assert lines[0] == "[guardrail] 1 passed | 1 failed | 0 running | 0 queued | 1 hard-gate failures"
     assert "[1/2] PASSED(SOFT) lint 1.2s" in lines
     assert "[2/2] FAILED(HARD) tests 2.2s" in lines
-    assert "[fitness tail]" in lines
+    assert "[guardrail tail]" in lines
     assert "[tests|HARD|FAILED] boom" in lines


### PR DESCRIPTION
## Summary

Clarifies that Entrix uses "fitness" in the evolutionary architecture sense while presenting user-facing concepts as quality guardrails.

- Adds README terminology guidance
- Updates CLI, MCP, reporter, and skill wording from generic fitness wording to guardrail/check language
- Keeps existing docs/fitness paths and core model/API names intact

## Validation

- [x] python3 -m compileall entrix
- [ ] ruff check .
- [ ] pytest

## Notes

Targeted pytest could not be run locally because pytest is not installed, and uv dependency resolution could not find pyyaml in the configured package registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing terminology to consistently use "guardrails" (reworded CLI help, README, skill docs, server and reporter text, and visual report titles)
  * Added a Terminology section clarifying "fitness" as executable quality guardrails
* **Tests**
  * Updated visual reporter snapshots to expect guardrail-oriented labels in live progress output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/entrix/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->